### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
       icu4j: 'com.ibm.icu:icu4j:51.1',
       guava: "com.google.guava:guava:${guava_version}",
       commons_codec: 'commons-codec:commons-codec:1.8',
-      commons_collections: 'commons-collections:commons-collections:3.2.1',
+      commons_collections: 'commons-collections:commons-collections:3.2.2',
       commons_io: 'commons-io:commons-io:2.4',
       commons_lang: 'commons-lang:commons-lang:2.6',
       cors_filter:'com.thetransactioncompany:cors-filter:2.4',


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/