### PR TITLE
Correct TextListSerializer to use an array

### DIFF
--- a/core/src/main/java/be/dnsbelgium/rdap/jackson/StructuredValueSerializer.java
+++ b/core/src/main/java/be/dnsbelgium/rdap/jackson/StructuredValueSerializer.java
@@ -36,6 +36,9 @@ public class StructuredValueSerializer extends JsonSerializer<StructuredValue> {
 
   @Override
   public void serialize(StructuredValue value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+    if (value.getComponents().length > 1) {
+      jgen.writeStartArray();
+    }
     for (StructuredValue.Component c : value.getComponents()) {
       // in a structured context, a list-component must start with [ and end with ]
       if (AbstractList.class.isAssignableFrom(c.value.getClass()) && ((AbstractList) c.value).getValues() != null && ((AbstractList) c.value).getValues().size() > 1) {
@@ -45,6 +48,9 @@ public class StructuredValueSerializer extends JsonSerializer<StructuredValue> {
       } else {
         provider.findValueSerializer(c.value.getClass(), null).serialize(c.value, jgen, provider);
       }
+    }
+    if (value.getComponents().length > 1) {
+      jgen.writeEndArray();
     }
   }
 }

--- a/core/src/test/groovy/be/dnsbelgium/rdap/jackson/StructuredValueSerializerTest.groovy
+++ b/core/src/test/groovy/be/dnsbelgium/rdap/jackson/StructuredValueSerializerTest.groovy
@@ -47,7 +47,7 @@ public class StructuredValueSerializerTest extends AbstractSerializerTest<Contac
 
     def expected = [
         ["version", [:], "text", "4.0"],
-        ["n", [:], "text", "family", "given", "additional", "prefix", "suffix"]
+        ["n", [:], "text", ["family", "given", "additional", "prefix", "suffix"]]
     ]
 
     this.serializeAndAssertEquals(getObjectMapper().writeValueAsString(expected), contact, serializerProvider);


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7095#section-3.3.1.3 (Structured Property Values) a multi-valued property is represented as a list.  This corrects the `ADR` type from:

    { "ADR", {}, "text", "", "", "", "", "", "", "" }

To:

    { "ADR", {}, "text", ["", "", "", "", "", "", ""] }