### PR TITLE
Add REGISTRAR_EXPIRATION as Action

### DIFF
--- a/core/src/main/java/be/dnsbelgium/rdap/core/Event.java
+++ b/core/src/main/java/be/dnsbelgium/rdap/core/Event.java
@@ -27,19 +27,26 @@ public class Event {
   public interface Action {
 
     enum Default implements Action {
-      REGISTRATION, REREGISTRATION, LAST_CHANGED{
-        public String getValue(){
-          return "last changed";
-        }
-      }, REGISTRAR_EXPIRATION, EXPIRATION, DELETION, REINSTANTIATION, TRANSFER, LOCKED, UNLOCKED, LAST_UPDATE_OF_RDAP_DATABASE{
-        public String getValue() {
-          return "last update of RDAP database";
-        }
-      };
+      REGISTRATION,
+      REREGISTRATION,
+      LAST_CHANGED,
+      EXPIRATION,
+      REGISTRAR_EXPIRATION,
+      DELETION,
+      REINSTANTIATION,
+      TRANSFER,
+      LOCKED,
+      UNLOCKED,
+      LAST_UPDATE_OF_RDAP_DATABASE("last update of RDAP database");
+
       private final String value;
 
       Default() {
-        this.value = name().toLowerCase(Locale.ENGLISH);
+        this.value = name().toLowerCase(Locale.ENGLISH).replace("_", " ");
+      }
+
+      Default(String value) {
+        this.value = value;
       }
 
       @Override
@@ -47,6 +54,7 @@ public class Event {
         return value;
       }
     }
+
     String getValue();
   }
 

--- a/core/src/main/java/be/dnsbelgium/rdap/core/Event.java
+++ b/core/src/main/java/be/dnsbelgium/rdap/core/Event.java
@@ -31,7 +31,7 @@ public class Event {
         public String getValue(){
           return "last changed";
         }
-      }, EXPIRATION, DELETION, REINSTANTIATION, TRANSFER, LOCKED, UNLOCKED, LAST_UPDATE_OF_RDAP_DATABASE{
+      }, REGISTRAR_EXPIRATION, EXPIRATION, DELETION, REINSTANTIATION, TRANSFER, LOCKED, UNLOCKED, LAST_UPDATE_OF_RDAP_DATABASE{
         public String getValue() {
           return "last update of RDAP database";
         }

--- a/core/src/test/java/be/dnsbelgium/core/EventTest.java
+++ b/core/src/test/java/be/dnsbelgium/core/EventTest.java
@@ -1,0 +1,30 @@
+package be.dnsbelgium.core;
+
+import be.dnsbelgium.rdap.core.Event;
+import org.junit.Test;
+
+import static be.dnsbelgium.rdap.core.Event.Action.Default.*;
+import static org.junit.Assert.assertEquals;
+
+public class EventTest {
+
+  @Test
+  public void testDefaultActions() {
+    assertActionValue(REGISTRATION, "registration");
+    assertActionValue(REREGISTRATION, "reregistration");
+    assertActionValue(LAST_CHANGED, "last changed");
+    assertActionValue(EXPIRATION, "expiration");
+    assertActionValue(REGISTRAR_EXPIRATION, "registrar expiration");
+    assertActionValue(DELETION, "deletion");
+    assertActionValue(REINSTANTIATION, "reinstantiation");
+    assertActionValue(TRANSFER, "transfer");
+    assertActionValue(LOCKED, "locked");
+    assertActionValue(UNLOCKED, "unlocked");
+    assertActionValue(LAST_UPDATE_OF_RDAP_DATABASE, "last update of RDAP database");
+  }
+
+  private static void assertActionValue(Event.Action action, String expected) {
+    assertEquals(expected, action.getValue());
+  }
+
+}


### PR DESCRIPTION
The latest requirements from 2025-09-30 sets the event "registrar expiration" as mandatory. Can we add the action as an enum field ?


<img width="816" height="793" alt="grafik" src="https://github.com/user-attachments/assets/a14916d0-f235-4bb4-8d72-7fe2608cbcc2" />


LINK : https://itp.cdn.icann.org/en/files/contracted-parties-communications/registrar-registration-expiration-date-30-09-2025-en.pdf